### PR TITLE
Update ScannerExecuter.java

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -43,6 +43,7 @@ public class ScannerExecuter {
 
 			microScannerDockerfileContent.append("FROM " + imageName + "\n");
 			microScannerDockerfileContent.append("ADD https://get.aquasec.com/microscanner .\n");
+			microScannerDockerfileContent.append("USER root\n");
 			microScannerDockerfileContent.append("RUN chmod +x microscanner\n");
 			microScannerDockerfileContent.append("ARG token\n");
 			microScannerDockerfileContent.append("RUN ./microscanner ${token} --html ");


### PR DESCRIPTION
A lot of containers will not run as root and thus does not have permission to set the execute attribute on microscanner - this will fix it and not change anything if container is already running as root