### PR TITLE
Adding a descriptive message upon failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+target/
 .idea/
 Dockerfile
 aqua-microscanner.hpi

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.console.ModelHyperlinkNote;
 import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.Symbol;
 
@@ -138,12 +139,14 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 		archiveArtifacts(build, workspace, launcher, listener);
 
 		System.out.println("exitCode: " + exitCode);
+    String disallowedMessage = "Image is non-compliant. See report: ";
 		String failedMessage = "Scanning failed.";
 		switch (exitCode) {
 		case OK_CODE:
 				System.out.println("Scanning success.");
 				break;
 		case DISALLOWED_CODE:
+        listener.getLogger().println(disallowedMessage + ModelHyperlinkNote.encodeTo(System.getenv("BUILD_URL")+"/artifact/"+artifactName,artifactName));
 				throw new AbortException(failedMessage);
 		default:
 			// This exception causes the message to appear in the Jenkins console


### PR DESCRIPTION
When build failed due to image compliance, no message was prompted to console explaining it.
As a result, it looked as if there was a problem with the plugin.

The pull request adds a message that says:
"Image is non-compliant. See report: " and links to the report artifact