### PR TITLE
Permission Denied when run Microscanner when WORKDIR declared as VOLUME

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -44,9 +44,8 @@ public class ScannerExecuter {
 			microScannerDockerfileContent.append("FROM " + imageName + "\n");
 			microScannerDockerfileContent.append("ADD https://get.aquasec.com/microscanner .\n");
 			microScannerDockerfileContent.append("USER 0\n");
-			microScannerDockerfileContent.append("RUN chmod +x microscanner\n");
 			microScannerDockerfileContent.append("ARG token\n");
-			microScannerDockerfileContent.append("RUN ./microscanner ${token} ").append("json".equalsIgnoreCase(outputFormat) ? "" : "--html ");
+			microScannerDockerfileContent.append("RUN chmod +x microscanner && ./microscanner ${token} ").append("json".equalsIgnoreCase(outputFormat) ? "" : "--html ");
 			if (checkonly)
 			{
 				microScannerDockerfileContent.append("--continue-on-failure ");


### PR DESCRIPTION
On some Docker images, WORKDIR is declared as VOLUME in the Dockerfile. This will cause an error when Aqua microscanner will be executed : 
```
/bin/sh: ./microscanner: Permission denied
```
This is a know behavior of docker layers that no capture changes on anonymous volume. See : https://serverfault.com/questions/772227/chmod-not-working-correctly-in-docker

You can easily reproduce the bug with this Dockerfile:
```
FROM alpine
RUN mkdir /opt/microscanner
WORKDIR /opt/microscanner

VOLUME ["/opt/microscanner"]

ADD https://get.aquasec.com/microscanner .
USER 0
RUN chmod +x microscanner
ARG token
RUN ./microscanner ${token} --html
```
A simple fix consists to execute `chmod` and run microscanner in the same RUN command.