### PR TITLE
Fixed artifact clashing issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 target/
 Dockerfile
 aqua-microscanner.hpi
+aqua-microscanner.iml

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaMicroScannerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaMicroScannerBuilder.java
@@ -16,6 +16,7 @@ import org.kohsuke.stapler.QueryParameter;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.util.UUID;
 
 import hudson.FilePath;
 import hudson.model.Run;
@@ -121,16 +122,17 @@ public class AquaMicroScannerBuilder extends Builder implements SimpleBuildStep{
 		// Support unique names for artifacts when there are multiple steps in the same
 		// build
 		String artifactSuffix, artifactName;
+		String randomFileString = UUID.randomUUID().toString().replaceAll("-", "");
 		if (build.hashCode() != buildId) {
 			// New build
 			setBuildId(build.hashCode());
 			setCount(1);
 			artifactSuffix = null; // When there is only one step, there should be no suffix at all
-			artifactName = "scanout." + outputFormat;
+			artifactName = String.format("scanout-%s.%s", randomFileString, outputFormat);
 		} else {
 			setCount(count + 1);
 			artifactSuffix = Integer.toString(count);
-			artifactName = "scanout-" + artifactSuffix + "." + outputFormat;
+			artifactName = String.format("scanout-%s-%s.%s", artifactSuffix, randomFileString, outputFormat);
 		}
 
 		int exitCode = ScannerExecuter.execute(build, workspace, launcher, listener, artifactName, microScannerToken, imageName, notCompliesCmd, outputFormat == null ? "html" : outputFormat, onDisallowed == null || !onDisallowed.equals("fail"),caCertificates);


### PR DESCRIPTION
This PR looks to address the issue of clashing artifact names when using related Aqua software Jenkins plugins. Adding a unique id to the filename will greatly reduce the chance of the plugin overwriting another artifact within the same build.